### PR TITLE
cmake support for locally installed libsnd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,10 @@ set (CMAKE_CXX_FLAGS_DEBUG         "-ggdb -DLINUX -Wall -W -Wno-unknown-pragmas 
 set (CMAKE_C_FLAGS_RELEASE         "-D_REENTRANT -Wall -DDEPURACION -DNDEBUG -O3 -Wno-unused-variable")
 set (CMAKE_CXX_FLAGS_RELEASE       "-DLINUX -Wall -W -O3 -DNDEBUG -Wno-unknown-pragmas -Wno-unused-result -Wno-unused-variable")
 
+set (LIBSND_INSTALL_DIR "" CACHE FILEPATH "Directory where libsndfile was installed")
+
 ##find libraries installed in the system
-FIND_LIBRARY(LIBSNDFILE sndfile)
+FIND_LIBRARY(LIBSNDFILE sndfile ${LIBSND_INSTALL_DIR}/lib)
 
 ##set particular settings for each architecture
 set (FFTREAL_HDRS ${CMAKE_CURRENT_SOURCE_DIR}/external/FFTReal-2.11)
@@ -37,7 +39,7 @@ endif()
 ##set some generic link directories
 LINK_DIRECTORIES(${os_link_libs})
 set (CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem") #needed for the SYSTEM link directories to work on osx
-INCLUDE_DIRECTORIES(SYSTEM ${os_include_libs})
+INCLUDE_DIRECTORIES(SYSTEM ${os_include_libs} ${LIBSND_INSTALL_DIR}/include)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/includes)
 
 #gather project files (note that when adding a new file cmake needs to be rerun)


### PR DESCRIPTION
- configable from command line as 'cmake -DLIBSND_INSTALL_DIR=/libsnd/install/dir .'
- not sure how it interacts in case when libsnd installed globally,
  should be tested (kaldi build of BeamFormIt builds libsnd locally)
